### PR TITLE
Update playback.js

### DIFF
--- a/js/playback.js
+++ b/js/playback.js
@@ -42,7 +42,20 @@ function armGestureUnlock() {
 
 export async function initAudio() {
   if (!state.audioCtx) {
-    state.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    const AC = window.AudioContext || window.webkitAudioContext;
+    state.audioCtx = new AC({ latencyHint: "interactive" });
+
+  // --- iOS/Safari: one-time silent unlock so audio actually routes ---
+  try {
+    const ctx = state.audioCtx;
+    const unlockBuffer = ctx.createBuffer(1, 1, ctx.sampleRate); // 1 frame silence
+    const unlockSrc = ctx.createBufferSource();
+    unlockSrc.buffer = unlockBuffer;
+    // If you have a master gain in state, prefer connecting through it:
+    (state.masterGain ? unlockSrc.connect(state.masterGain) : unlockSrc.connect(ctx.destination));
+    try { unlockSrc.start(0); } catch {}
+  } catch {}
+  // -------------------------------------------------------------------
     // Decode and cache AudioBuffers for the configured `state.sounds` keys
     state.audioBuffers = await Promise.all(
       state.sounds.map(async (key) => {
@@ -52,7 +65,11 @@ export async function initAudio() {
           return null;
         }
         const arrayBuffer = dataUrlToArrayBuffer(url);
-        return await state.audioCtx.decodeAudioData(arrayBuffer);
+        // Safari/WebKit: use callback form wrapped in a Promise
+        return await new Promise((resolve, reject) => {
+          const fresh = arrayBuffer.slice(0); // Some builds require a fresh copy
+          state.audioCtx.decodeAudioData(fresh, resolve, reject);
+        });
       })
     );
   }
@@ -64,6 +81,24 @@ export async function initAudio() {
 
   // If we still aren’t running (iOS first-gesture rules), arm a one-time unlock
   if (state.audioCtx.state !== "running") armGestureUnlock();
+
+  // Arm a one-time global resume in case iOS suspends after creation
+  if (!unlockArmed && 'addEventListener' in document) {
+    unlockArmed = true;
+    const tryResume = async () => {
+      if (!state.audioCtx) return;
+      try { await state.audioCtx.resume(); } catch {}
+      if (state.audioCtx.state === "running") {
+        ["pointerdown","touchend","click","keydown"].forEach(t =>
+          document.removeEventListener(t, tryResume, true)
+        );
+      }
+    };
+    ["pointerdown","touchend","click","keydown"].forEach(t =>
+      document.addEventListener(t, tryResume, true)
+    );
+  }
+
 }
 
 // Minimal helper other modules can call before scheduling audio


### PR DESCRIPTION
Mosre defensive programming for iOS playback issues on certain model iPhones. iOS 18.6.2 in particular, though the bug report this is in response to turned out to be a configuration error. According to the bug report, "My phone was on silent mode for alerts. When I put it on normal mode it worked fine." Don't ask me why silencing alerts also silences a web page.

In short, this code is not needed, but explicitly attempts to check for the presence of audio at several points.